### PR TITLE
set cache manager delegate before download

### DIFF
--- a/Sources/Managers/TileCacheManager.swift
+++ b/Sources/Managers/TileCacheManager.swift
@@ -59,8 +59,7 @@ class TileCacheManager: NSObject {
         return fullImageSize.constrainToSize(size)
     }
 
-    init(highResolutionImageRemoteURL: URL,
-         imageViewSize: CGSize,
+    init(imageViewSize: CGSize,
          options: HugeImageOptions? = nil,
          downloadManager: DownloadManaging? = nil) {
         self.imageCacheIdentifier = ImageCacheIdentifier(id: options?.imageID ?? UUID().uuidString)
@@ -73,7 +72,6 @@ class TileCacheManager: NSObject {
 
         setupCache()
         self.downloadManager.delegate = self
-        self.downloadManager.downloadImageFromURL(highResolutionImageRemoteURL)
     }
 
     func urlPathFor(prefix: String, row: Int, col: Int) -> URL? {
@@ -107,6 +105,10 @@ class TileCacheManager: NSObject {
             return
         }
         try? fileManager.createDirectory(atPath: dataCacheDirectoryPath, withIntermediateDirectories: true, attributes: nil)
+    }
+    
+    func startDownload(highResolutionImageRemoteURL: URL) {
+        self.downloadManager.downloadImageFromURL(highResolutionImageRemoteURL)
     }
 
     private func clearImageCache() {

--- a/Sources/Views/HugeImageView.swift
+++ b/Sources/Views/HugeImageView.swift
@@ -66,8 +66,9 @@ extension HugeImageView {
     @discardableResult
     public func load(highResolutionImageRemoteURL: URL) -> ImageCacheIdentifier {
         layoutIfNeeded()
-        let tileCacheManager = TileCacheManager(highResolutionImageRemoteURL: highResolutionImageRemoteURL, imageViewSize: bounds.size)
+        let tileCacheManager = TileCacheManager(imageViewSize: bounds.size)
         tileCacheManager.delegate = self
+        tileCacheManager.startDownload(highResolutionImageRemoteURL: highResolutionImageRemoteURL)
         let imageCacheIdentifier = tileCacheManager.imageCacheIdentifier
         hugeImageScrollView.configure(tileCacheManager: tileCacheManager, imageCacheIdentifier: imageCacheIdentifier)
         return imageCacheIdentifier
@@ -76,8 +77,9 @@ extension HugeImageView {
     @discardableResult
     public func load(highResolutionImageRemoteURL: URL, withOptions options: HugeImageOptions) -> ImageCacheIdentifier {
         layoutIfNeeded()
-        let tileCacheManager = TileCacheManager(highResolutionImageRemoteURL: highResolutionImageRemoteURL, imageViewSize: bounds.size, options: options)
+        let tileCacheManager = TileCacheManager(imageViewSize: bounds.size, options: options)
         tileCacheManager.delegate = self
+        tileCacheManager.startDownload(highResolutionImageRemoteURL: highResolutionImageRemoteURL)
         let imageCacheIdentifier = tileCacheManager.imageCacheIdentifier
         hugeImageScrollView.configure(tileCacheManager: tileCacheManager, imageCacheIdentifier: imageCacheIdentifier, options: options)
         return imageCacheIdentifier


### PR DESCRIPTION
This change ensures that the line `tileCacheManager.delegate = self` happens before the download finishes.

When the download finishes, one of the callback functions is `delegate?.tileCacheManagerDidFinishDownloadingHighResolutionImage(self, withResult: result)`. If `DownloadManaging.downloadImageFromURL(_:)` is implemented synchonously (e.g. you're loading from a local file instead of downloading remotely), then calling its `DownloadManagerDelegate`'s `downloadManagerDidFinishDownloading(_:withResult:)` function eventually hits `delegate?.tileCacheManagerDidFinishDownloadingHighResolutionImage(self, withResult: result)` while that `delegate` is still nil.

Setting the `TileCacheManager`'s delegate before initiating the download guarantees that the delegate will be set before the download callbacks happen, no matter how long the download takes.